### PR TITLE
feat(settings): add autosave interval option

### DIFF
--- a/DOCS.MD
+++ b/DOCS.MD
@@ -79,6 +79,7 @@ Key files:
 - Settings screen controls editor preferences, keyboard layout, and device options.
 - Margin size, font size, and brightness are applied immediately to the editor.
 - Typewriter mode toggles centered-line scrolling vs normal scrolling and applies immediately.
+- Autosave interval controls the idle time before background autosave (1/2/3/5/10/15/30/60 minutes).
 - The settings list auto-scrolls to keep the focused item visible when navigating with keys or touch (landscape included).
 
 Key files:

--- a/assets/strings/en.json
+++ b/assets/strings/en.json
@@ -124,6 +124,7 @@
     "font_large": "Large",
     "keyboard_layout": "Keyboard layout",
     "auto_sleep": "Auto-sleep",
+    "autosave_interval": "Autosave interval",
     "brightness": "Brightness",
     "auto_sleep_off": "Off",
     "auto_sleep_5": "5 minutes",

--- a/components/scribe_storage/settings_store.cpp
+++ b/components/scribe_storage/settings_store.cpp
@@ -16,6 +16,18 @@ constexpr int kMarginMin = 0;
 constexpr int kMarginMax = 2;
 constexpr int kBrightnessMin = 0;
 constexpr int kBrightnessMax = 100;
+
+int normalizeAutosaveInterval(int value) {
+    constexpr size_t kIntervalCount =
+        sizeof(SettingsDefaults::kAutosaveIntervalOptions) /
+        sizeof(SettingsDefaults::kAutosaveIntervalOptions[0]);
+    for (size_t i = 0; i < kIntervalCount; ++i) {
+        if (SettingsDefaults::kAutosaveIntervalOptions[i] == value) {
+            return value;
+        }
+    }
+    return SettingsDefaults::kAutosaveIntervalDefault;
+}
 }  // namespace
 
 SettingsStore& SettingsStore::getInstance() {
@@ -170,6 +182,12 @@ esp_err_t SettingsStore::load(AppSettings& settings) {
         settings.backup_enabled = cJSON_IsTrue(backup);
     }
 
+    cJSON* autosave_interval = cJSON_GetObjectItem(root, "autosave_interval");
+    if (cJSON_IsNumber(autosave_interval)) {
+        settings.autosave_interval = autosave_interval->valueint;
+    }
+    settings.autosave_interval = normalizeAutosaveInterval(settings.autosave_interval);
+
     cJSON_Delete(root);
     ESP_LOGI(TAG, "Settings loaded: theme=%s, font=%d, ui_scale=%d, sleep=%d",
              settings.theme_id.c_str(),
@@ -184,7 +202,7 @@ esp_err_t SettingsStore::save(const AppSettings& settings) {
     StorageManager::getInstance().ensureDirectories();
 
     cJSON* root = cJSON_CreateObject();
-    cJSON_AddNumberToObject(root, "version", 7);
+    cJSON_AddNumberToObject(root, "version", 8);
     const char* theme_id = settings.theme_id.empty() ? "dracula" : settings.theme_id.c_str();
     cJSON_AddStringToObject(root, "theme_id", theme_id);
     const char* editor_font = settings.editor_font_id.empty() ? "montserrat" : settings.editor_font_id.c_str();
@@ -199,6 +217,7 @@ esp_err_t SettingsStore::save(const AppSettings& settings) {
     cJSON_AddBoolToObject(root, "wifi_enabled", settings.wifi_enabled);
     cJSON_AddNumberToObject(root, "brightness", settings.brightness);
     cJSON_AddBoolToObject(root, "backup_enabled", settings.backup_enabled);
+    cJSON_AddNumberToObject(root, "autosave_interval", settings.autosave_interval);
 
     char* json_str = cJSON_Print(root);
     cJSON_Delete(root);

--- a/components/scribe_storage/settings_store.h
+++ b/components/scribe_storage/settings_store.h
@@ -3,6 +3,11 @@
 #include <esp_err.h>
 #include <string>
 
+namespace SettingsDefaults {
+inline constexpr int kAutosaveIntervalDefault = 1;
+inline constexpr int kAutosaveIntervalOptions[] = {1, 2, 3, 5, 10, 15, 30, 60};
+}  // namespace SettingsDefaults
+
 // Application settings persistence
 // Stores user preferences in /Scribe/settings.json per SPECS.md section 5
 
@@ -43,6 +48,9 @@ struct AppSettings {
 
     // Cloud backup enabled
     bool backup_enabled = false;
+
+    // Autosave interval in minutes
+    int autosave_interval = SettingsDefaults::kAutosaveIntervalDefault;
 };
 
 class SettingsStore {

--- a/components/scribe_ui/ui_app.cpp
+++ b/components/scribe_ui/ui_app.cpp
@@ -125,6 +125,40 @@ bool getImuOrientation(MIPIDSI::Orientation& orientation) {
     }
     return true;
 }
+
+int normalizeAutosaveIntervalSetting(int value) {
+    constexpr size_t kIntervalCount =
+        sizeof(SettingsDefaults::kAutosaveIntervalOptions) /
+        sizeof(SettingsDefaults::kAutosaveIntervalOptions[0]);
+    for (size_t i = 0; i < kIntervalCount; ++i) {
+        if (SettingsDefaults::kAutosaveIntervalOptions[i] == value) {
+            return value;
+        }
+    }
+    return SettingsDefaults::kAutosaveIntervalDefault;
+}
+
+int stepAutosaveIntervalSetting(int current, int delta) {
+    constexpr size_t kIntervalCount =
+        sizeof(SettingsDefaults::kAutosaveIntervalOptions) /
+        sizeof(SettingsDefaults::kAutosaveIntervalOptions[0]);
+    if (kIntervalCount == 0) {
+        return SettingsDefaults::kAutosaveIntervalDefault;
+    }
+    int index = 0;
+    for (size_t i = 0; i < kIntervalCount; ++i) {
+        if (SettingsDefaults::kAutosaveIntervalOptions[i] == current) {
+            index = static_cast<int>(i);
+            break;
+        }
+    }
+    int next = index + delta;
+    while (next < 0) {
+        next += static_cast<int>(kIntervalCount);
+    }
+    next = next % static_cast<int>(kIntervalCount);
+    return SettingsDefaults::kAutosaveIntervalOptions[next];
+}
 }  // namespace
 
 struct UIApp::WiFiEvent {
@@ -463,6 +497,12 @@ esp_err_t UIApp::init() {
             } else {
                 int next = settings_.brightness + (value * 10);
                 settings_.brightness = std::max(0, std::min(100, next));
+            }
+        } else if (setting == "autosave_interval") {
+            if (absolute) {
+                settings_.autosave_interval = normalizeAutosaveIntervalSetting(value);
+            } else {
+                settings_.autosave_interval = stepAutosaveIntervalSetting(settings_.autosave_interval, value);
             }
         } else if (setting == "keyboard_layout") {
             settings_.keyboard_layout = (settings_.keyboard_layout + value + 5) % 5;

--- a/components/scribe_ui/ui_app.h
+++ b/components/scribe_ui/ui_app.h
@@ -152,6 +152,7 @@ public:
     void setRecoveredContent(const std::string& project_id, const std::string& content);
     void setSaving(bool saving) { saving_ = saving; }
     bool isSaving() const { return saving_; }
+    int getAutosaveIntervalMinutes() const { return settings_.autosave_interval; }
 
 private:
     UIApp() : running_(false), hud_visible_(false),

--- a/components/scribe_ui/ui_screens/screen_settings.cpp
+++ b/components/scribe_ui/ui_screens/screen_settings.cpp
@@ -52,6 +52,12 @@ static std::string brightnessLabel(int value) {
     return std::string(buf);
 }
 
+static std::string autosaveIntervalLabel(int minutes) {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d min", minutes);
+    return std::string(buf);
+}
+
 static const char* autoSleepLabel(int value) {
     Strings& strings = Strings::getInstance();
     switch (value) {
@@ -188,6 +194,8 @@ void ScreenSettings::rebuildList() {
     addItem(strings.get("settings.margin"), marginLabel(settings_.editor_margin), "editor_margin", LV_SYMBOL_LIST);
     addItem(strings.get("settings.typewriter_mode"), typewriterModeLabel(settings_.typewriter_mode),
             "typewriter_mode", LV_SYMBOL_EDIT);
+    std::string autosave_label = autosaveIntervalLabel(settings_.autosave_interval);
+    addItem(strings.get("settings.autosave_interval"), autosave_label.c_str(), "autosave_interval", LV_SYMBOL_SAVE);
     addItem(strings.get("settings.keyboard_layout"), keyboardLayoutLabel(settings_.keyboard_layout), "keyboard_layout", LV_SYMBOL_KEYBOARD);
     addItem(strings.get("settings.auto_sleep"), autoSleepLabel(settings_.auto_sleep), "auto_sleep", LV_SYMBOL_GPS);
     std::string brightness_label = brightnessLabel(settings_.brightness);
@@ -282,7 +290,7 @@ void ScreenSettings::selectCurrent() {
         return;
     }
     if (key == "font_size" || key == "ui_scale" || key == "editor_font" ||
-        key == "editor_margin" || key == "brightness") {
+        key == "editor_margin" || key == "brightness" || key == "autosave_interval") {
         showPicker(key);
         return;
     }
@@ -394,6 +402,14 @@ void ScreenSettings::showPicker(const std::string& key) {
             }
         }
         lv_label_set_text(picker_title_, strings.get("settings.brightness"));
+    } else if (picker_key_ == "autosave_interval") {
+        for (int value : SettingsDefaults::kAutosaveIntervalOptions) {
+            picker_options_.push_back({autosaveIntervalLabel(value), value, ""});
+            if (settings_.autosave_interval == value) {
+                picker_index_ = static_cast<int>(picker_options_.size() - 1);
+            }
+        }
+        lv_label_set_text(picker_title_, strings.get("settings.autosave_interval"));
     } else {
         return;
     }

--- a/main/app_main.cpp
+++ b/main/app_main.cpp
@@ -462,7 +462,15 @@ static void ui_task(void* arg) {
 
     // Autosave timer tracking
     TickType_t last_keypress_time = xTaskGetTickCount();
-    const TickType_t autosave_delay = pdMS_TO_TICKS(5000);  // 5 seconds idle
+    auto autosaveDelayFromMinutes = [](int minutes) -> TickType_t {
+        if (minutes <= 0) {
+            minutes = 1;
+        }
+        uint32_t ms = static_cast<uint32_t>(minutes) * 60U * 1000U;
+        return pdMS_TO_TICKS(ms);
+    };
+    int autosave_interval_minutes = ui.getAutosaveIntervalMinutes();
+    TickType_t autosave_delay = autosaveDelayFromMinutes(autosave_interval_minutes);
     const TickType_t ui_tick = pdMS_TO_TICKS(5);
     uint64_t last_saved_revision = 0;
     uint64_t last_seen_revision = 0;
@@ -827,7 +835,13 @@ static void ui_task(void* arg) {
             }
         }
 
-        // Check for autosave trigger (every 5 seconds of idle time)
+        int next_interval_minutes = ui.getAutosaveIntervalMinutes();
+        if (next_interval_minutes != autosave_interval_minutes) {
+            autosave_interval_minutes = next_interval_minutes;
+            autosave_delay = autosaveDelayFromMinutes(autosave_interval_minutes);
+        }
+
+        // Check for autosave trigger (idle interval)
         TickType_t current_time = xTaskGetTickCount();
         bool dirty = last_seen_revision > last_saved_revision;
         if (dirty && inflight_saves == 0 && !storage.isSuspended() &&


### PR DESCRIPTION
## Summary
- add autosave interval setting (1/2/3/5/10/15/30/60 minutes) in Settings and persist in settings.json
- drive autosave idle delay from the selected interval
- update strings and DOCS.MD for the new setting

## Testing
- not run (hardware build)

## Checklist
- [ ] Meets acceptance criteria
- [ ] Docs/strings updated if needed

Fixes #11
